### PR TITLE
Re-render thumbnails when images change

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -38,7 +38,8 @@ class Gallery extends Component {
 
         if(this.state.images != np.images){
             this.setState({
-                images: np.images
+                images: np.images,
+                thumbnails: this.renderThumbs(this._gallery.clientWidth, np.images)
             });
         }
     }
@@ -170,16 +171,16 @@ class Gallery extends Component {
                        * (item.thumbnailWidth / item.thumbnailHeight));
     }
 
-    renderThumbs (containerWidth) {
-        if (!this.state.images) return [];
+    renderThumbs (containerWidth, images = this.state.images) {
+        if (!images) return [];
         if (containerWidth == 0) return [];
 
-        var items = this.state.images.slice();
+        var items = images.slice();
         for (var t in items) {
             this.setThumbScale(items[t]);
         }
 
-        var images = [];
+        var thumbs = [];
         var rows = [];
         while(items.length > 0) {
             rows.push(this.buildImageRow(items, containerWidth));
@@ -188,10 +189,10 @@ class Gallery extends Component {
         for(var r in rows) {
             for(var i in rows[r]) {
                 var item = rows[r][i];
-                images.push(item);
+                thumbs.push(item);
             }
         }
-        return images;
+        return thumbs;
     }
 
     render () {


### PR DESCRIPTION
Currently [only thumbnails are updated when `images` props changes](https://github.com/benhowell/react-grid-gallery/blob/90465cf2a64185677ea692eb8246df6e775660b2/src/Gallery.js#L39-L43), meaning [re-render doesn't happen](https://github.com/benhowell/react-grid-gallery/blob/90465cf2a64185677ea692eb8246df6e775660b2/src/Gallery.js#L198) until [window is resized](https://github.com/benhowell/react-grid-gallery/blob/90465cf2a64185677ea692eb8246df6e775660b2/src/Gallery.js#L58):

![example of the issue](https://cloud.githubusercontent.com/assets/389387/18413902/bf18acb6-77bf-11e6-9b1e-008cafdb16dd.gif)

If you think of a better fix than mine, here's [the code I used to replicate this issue](http://www.webpackbin.com/4k-jRI6j-).