### PR TITLE
Make sure React knows that each image is a unique entity

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -197,7 +197,7 @@ class Gallery extends Component {
     render () {
         var images = this.state.thumbnails.map((item, idx) => {
             return <Image
-            key={"Image-"+idx}
+            key={item.src}
             item={item}
             index={idx}
             margin={this.props.margin}


### PR DESCRIPTION
Right now [React assumes that images differ only by their index](https://github.com/benhowell/react-grid-gallery/blob/90465cf2a64185677ea692eb8246df6e775660b2/src/Gallery.js#L200) and just switches the `src` attribuite when images change, leading to weird display bug while new images load:

![example of the issue](https://cloud.githubusercontent.com/assets/389387/18413970/04b0434a-77c2-11e6-84dd-954e1af0e50f.gif)

I think using URLs as keys should be the optimal solution here.

(Code from the PR #6 can be used to test this as well)