### PR TITLE
Fix unitless values in styles

### DIFF
--- a/src/Image.js
+++ b/src/Image.js
@@ -119,10 +119,10 @@ class Image extends Component {
                 padding: "2px",
                 pointerEvents: "none",
                 position: "absolute",
-                minHeight: "0",
+                minHeight: "0px",
                 maxHeight: "160px",
                 width: "100%",
-                bottom: "0"
+                bottom: "0px"
             }}>
                 {tags}
             </div>


### PR DESCRIPTION
Seems like React does not like setting style values to unitless values (in this case to `0`).
When you do such a thing it complains:

<img width="735" alt="zrzut ekranu 2016-10-05 o 15 57 31" src="https://cloud.githubusercontent.com/assets/1729299/19116054/764a6836-8b14-11e6-9ccd-fff935a0a215.png">

I couldn't bundled everything because of lack of require.js file in repo so here are changes required, but without bundled changes