### PR TITLE
Add events for lightboxWillOpen and lightboxWillClose

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ rowHeight               | number        | 180           | Optional. The height o
 margin                  | number        | 2             | Optional. The margin around each image in the gallery.
 enableLightbox          | bool          | true          | Optional. Enable lightbox display of full size image when thumbnail clicked.
 onClickThumbnail        | func          | openLightbox  | Optional. Function to execute when gallery thumbnail clicked. Optional args: index (index of selected image in images array), event (the click event). Overrides openLightbox.
-
+lightboxWillOpen        | func          | undefined     | Optional. Function to be called before opening lightbox. Optional arg: index (index of selected image in images array).
+lightboxWillClose       | func          | undefined     | Optional. Function to be called before closing lightbox.
 
 ## Lightbox Options
 NOTE: these options are passed inside the Gallery tag.

--- a/examples/index.html
+++ b/examples/index.html
@@ -188,6 +188,18 @@
 <td align="left">openLightbox</td>
 <td align="left">Optional. Function to execute when gallery thumbnail clicked. Optional args: index (index of selected image in images array), event (the click event). Overrides openLightbox.</td>
 </tr>
+<tr>
+<td align="left">lightboxWillOpen</td>
+<td align="left">func</td>
+<td align="left">undefined</td>
+<td align="left">Optional. Function to be called before opening lightbox. Optional arg: index (index of selected image in images array).</td>
+</tr>
+<tr>
+<td align="left">lightboxWillClose</td>
+<td align="left">func</td>
+<td align="left">undefined</td>
+<td align="left">Optional. Function to be called before closing lightbox.</td>
+</tr>
 </tbody></table>
 
 <h2><a id="user-content-lightbox-options" class="anchor" href="#lightbox-options" aria-hidden="true"></a>Lightbox Options</h2>

--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -56,6 +56,10 @@ class Gallery extends Component {
 
     openLightbox (index, event) {
         event.preventDefault();
+        if (this.props.lightboxWillOpen) {
+            this.props.lightboxWillOpen(index);
+        }
+
         this.setState({
             currentImage: index,
             lightboxIsOpen: true
@@ -63,6 +67,10 @@ class Gallery extends Component {
     }
 
     closeLightbox () {
+        if (this.props.lightboxWillClose) {
+            this.props.lightboxWillClose();
+        }
+
         this.setState({
             currentImage: 0,
             lightboxIsOpen: false
@@ -262,6 +270,8 @@ Gallery.propTypes = {
     rowHeight: PropTypes.number,
     margin: PropTypes.number,
     onClickThumbnail: PropTypes.func,
+    lightboxWillOpen: PropTypes.func,
+    lightboxWillClose: PropTypes.func,
     enableLightbox: PropTypes.bool,
     backdropClosesModal: PropTypes.bool,
     currentImage: PropTypes.number,


### PR DESCRIPTION
Hi,

Added events to be fired before opening the lightbox and before closing the lightbox.
The `lightboxWillOpen` event passes as arg the relevant image index. This is necessary when using the `customControls` property of lightbox, we need to know what is the current displayed image so any operation from the custom controls will be run on it.

The `lightboxWillClose` event is... not necessary but added if for the sake of completion :)
Thx