### PR TITLE
openLightbox can now be called without a event

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -57,7 +57,9 @@ class Gallery extends Component {
     }
 
     openLightbox (index, event) {
-        event.preventDefault();
+        if (event) {
+            event.preventDefault();
+        }
         if (this.props.lightboxWillOpen) {
             this.props.lightboxWillOpen(index);
         }


### PR DESCRIPTION
In some situations it may make sense to have the page load with the lightbox open, and in those cases it would not make sense to pass in a event.