### PR TITLE
fix(Gallery): Should update thumbnails when maxRows changes

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -31,7 +31,7 @@ class Gallery extends Component {
     }
 
     componentWillReceiveProps (np) {
-        if(this.state.images != np.images){
+        if(this.state.images != np.images || this.props.maxRows != np.maxRows){
             this.setState({
                 images: np.images,
                 thumbnails: this.renderThumbs(this._gallery.clientWidth,


### PR DESCRIPTION
I was using some JS to change whether we showed 1 row or two on a breakpoint and some other funky js due to SSR which meant I have to render 1 row then figure out if we show 2 and noticed that when I changed the maxRows setting the thumbnails didn't update.

This PR fixes that.