### PR TITLE
fix(Resize): Resize event didn’t trigger on scroll bar

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -27,7 +27,6 @@ class Gallery extends Component {
 
     componentDidMount () {
         this.onResize();
-        window.addEventListener('resize', this.onResize);
     }
 
     componentWillReceiveProps (np) {
@@ -250,9 +249,19 @@ class Gallery extends Component {
             tileViewportStyle={this.props.tileViewportStyle}
             thumbnailStyle={this.props.thumbnailStyle}
                 />;});
-
+        var resizeIframeStyles = {
+            height: 0,
+            margin: 0,
+            padding: 0,
+            overflow: "hidden",
+            borderWidth: 0,
+            position: "fixed",
+            backgroundColor: "transparent",
+            width: "100%"
+        };
         return (
                 <div id={this.props.id} className="ReactGridGallery" ref={(c) => this._gallery = c}>
+                    <iframe style={resizeIframeStyles} ref={(c) => c && c.contentWindow.addEventListener('resize', this.onResize) } />
                 {images}
                 <Lightbox
             images={this.props.images}


### PR DESCRIPTION
Watching for the window resize event meant that when you close a lightbox the width would not be calculated correctly leading to incorrect wrapping.

For reference see:
- https://stackoverflow.com/questions/2175992/detect-when-window-vertical-scrollbar-appears
- https://gist.github.com/AdamMcCormick/d5f718d2e9569acdf7def25e8266bb2a

Here's a video of the issue we are seeing: https://screencast.com/t/WOrdVr9Sk