### PR TITLE
+Selectable caption

### DIFF
--- a/src/Image.js
+++ b/src/Image.js
@@ -193,7 +193,8 @@ class Image extends Component {
                         background: "white",
                         height: "100%",
                         width: "100%",
-                        margin: 0
+                        margin: 0,
+                        userSelect: "text"
                     }}>
                         {this.props.item.thumbnailCaption}
                     </div>


### PR DESCRIPTION
Hi, 
thanks for merging & clean up caption feature. 

I noticed lib uses user-select: none, which I am sure has its reasons but for text caption its quite user unfriendly. In this PR, I only added userSelect: "text" to div which wraps thumbnailCaption as it makes it selectable in browser.

Please take a look at it. Thanks.

