### PR TITLE
Added a capability to rotate Thumbnail images  according to exif orientation property

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ caption                 | string        | undefined     | Optional. Image captio
 srcSet 	                | array         | undefined 	| Optional. Array of srcSets for lightbox.
 customOverlay           | element       | undefined     | Optional. A custom element to be rendered as a thumbnail overlay on hover.
 thumbnailCaption        | string&#124;element | undefined     | Optional. A thumbnail caption shown below thumbnail.
+orientation          | number        | undefined     | Optional. Orientation of the image. Many newer digital cameras (both dSLR and Point & Shoot digicams) have a built-in orientation sensor. The output of this sensor is used to set the EXIF orientation flag in the image file's metatdata to reflect the positioning of the camera with respect to the ground.
 
 ## Gallery Options
 

--- a/examples/different-orientations-example.js
+++ b/examples/different-orientations-example.js
@@ -1,0 +1,88 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Gallery from '../src/Gallery';
+
+
+class DifferentOrientationsExample extends React.Component {
+    constructor(props){
+        super(props);
+
+        this.state = {
+            images: this.props.images
+        };
+
+    }
+
+    render () {
+        return (
+                <div style={{
+                    display: "block",
+                    minHeight: "1px",
+                    width: "100%",
+                    border: "1px solid #ddd",
+                    overflow: "auto"}}>
+                <Gallery
+            images={this.state.images}
+                />
+                </div>
+        );
+    }
+}
+
+DifferentOrientationsExample.propTypes = {
+    images: PropTypes.arrayOf(
+        PropTypes.shape({
+            src: PropTypes.string.isRequired,
+            thumbnail: PropTypes.string.isRequired,
+            thumbnailWidth: PropTypes.number.isRequired,
+            thumbnailHeight: PropTypes.number.isRequired,
+            orientation: PropTypes.number
+        })
+    ).isRequired
+};
+
+DifferentOrientationsExample.defaultProps = {
+    images: shuffleArray([
+        {
+            src: "https://c5.staticflickr.com/9/8768/28941110956_b05ab588c1_b.jpg",
+            thumbnail: "https://c5.staticflickr.com/9/8768/28941110956_b05ab588c1_n.jpg",
+            thumbnailWidth: 240,
+            thumbnailHeight: 320,
+            orientation: 1 /* the orientation of the image can be extracted from exif orientation property 
+            'exif.Orientation'. This can be done using libraries like 'lodash', lodash has a method '_get'
+            that can be used as follows: 
+            orientation = _get(imageObject, 'exif.Orientation', 1);
+            */
+        },
+        {
+            src: "https://c3.staticflickr.com/9/8583/28354353794_9f2d08d8c0_b.jpg",
+            thumbnail: "https://c3.staticflickr.com/9/8583/28354353794_9f2d08d8c0_n.jpg",
+            thumbnailWidth: 320,
+            thumbnailHeight: 190,
+            orientation: 6
+        },
+        {
+            src: "https://c7.staticflickr.com/9/8569/28941134686_d57273d933_b.jpg",
+            thumbnail: "https://c7.staticflickr.com/9/8569/28941134686_d57273d933_n.jpg",
+            thumbnailWidth: 320,
+            thumbnailHeight: 148,
+            orientation: 3
+        },
+        {
+            src: "https://c6.staticflickr.com/9/8342/28897193381_800db6419e_b.jpg",
+            thumbnail: "https://c6.staticflickr.com/9/8342/28897193381_800db6419e_n.jpg",
+            thumbnailWidth: 320,
+            thumbnailHeight: 213,
+            orientation: 8
+        },
+        {
+            src: "https://c2.staticflickr.com/9/8239/28897202241_1497bec71a_b.jpg",
+            thumbnail: "https://c2.staticflickr.com/9/8239/28897202241_1497bec71a_n.jpg",
+            thumbnailWidth: 248,
+            thumbnailHeight: 320
+        }
+    ])
+};
+
+ReactDOM.render(<DifferentOrientationsExample />, document.getElementById('differentOrientationsExample'));

--- a/lib/Image.js
+++ b/lib/Image.js
@@ -78,6 +78,18 @@ var Image = function (_Component) {
         key: 'thumbnailStyle',
         value: function thumbnailStyle() {
             if (this.props.thumbnailStyle) return this.props.thumbnailStyle.call(this);
+            var transformValue = undefined;
+            switch (this.props.item.orientation) {
+            case 3:
+                  transformValue = "rotate(180deg)";
+                  break;
+                case 6:
+                  transformValue = "rotate(90deg)";
+                  break;
+                case 8:
+                  transformValue = "rotate(270deg)";
+                  break;
+            }
             if (this.props.item.isSelected) {
                 var ratio = this.props.item.scaletwidth / this.props.height;
                 var height = 0;
@@ -100,7 +112,8 @@ var Image = function (_Component) {
                     width: width,
                     height: height,
                     marginLeft: marginLeft,
-                    marginTop: marginTop
+                    marginTop: marginTop,
+                    transform: transformValue
                 };
             }
             return {
@@ -108,7 +121,8 @@ var Image = function (_Component) {
                 width: this.props.item.scaletwidth,
                 height: this.props.height,
                 marginLeft: this.props.item.marginLeft,
-                marginTop: 0
+                marginTop: 0,
+                transform: transformValue
             };
         }
     }, {

--- a/lib/Image.js
+++ b/lib/Image.js
@@ -78,18 +78,6 @@ var Image = function (_Component) {
         key: 'thumbnailStyle',
         value: function thumbnailStyle() {
             if (this.props.thumbnailStyle) return this.props.thumbnailStyle.call(this);
-            var transformValue = undefined;
-            switch (this.props.item.orientation) {
-            case 3:
-                  transformValue = "rotate(180deg)";
-                  break;
-                case 6:
-                  transformValue = "rotate(90deg)";
-                  break;
-                case 8:
-                  transformValue = "rotate(270deg)";
-                  break;
-            }
             if (this.props.item.isSelected) {
                 var ratio = this.props.item.scaletwidth / this.props.height;
                 var height = 0;
@@ -112,8 +100,7 @@ var Image = function (_Component) {
                     width: width,
                     height: height,
                     marginLeft: marginLeft,
-                    marginTop: marginTop,
-                    transform: transformValue
+                    marginTop: marginTop
                 };
             }
             return {
@@ -121,8 +108,7 @@ var Image = function (_Component) {
                 width: this.props.item.scaletwidth,
                 height: this.props.height,
                 marginLeft: this.props.item.marginLeft,
-                marginTop: 0,
-                transform: transformValue
+                marginTop: 0
             };
         }
     }, {

--- a/src/Image.js
+++ b/src/Image.js
@@ -49,6 +49,19 @@ class Image extends Component {
     thumbnailStyle () {
         if (this.props.thumbnailStyle)
             return this.props.thumbnailStyle.call(this);
+            
+        var rotationTransformValue = undefined;
+        switch (this.props.item.orientation) {
+            case 3:
+                rotationTransformValue = "rotate(180deg)";
+                break;
+            case 6:
+                rotationTransformValue = "rotate(90deg)";
+                break;
+            case 8:
+                rotationTransformValue = "rotate(270deg)";
+                break;
+        }
         if (this.props.item.isSelected){
             var ratio = (this.props.item.scaletwidth / this.props.height);
             var height = 0;
@@ -72,7 +85,8 @@ class Image extends Component {
                 width: width,
                 height: height,
                 marginLeft: marginLeft,
-                marginTop: marginTop
+                marginTop: marginTop,
+                transform: rotationTransformValue
             };
         }
         return {
@@ -80,7 +94,8 @@ class Image extends Component {
             width: this.props.item.scaletwidth,
             height: this.props.height,
             marginLeft: this.props.item.marginLeft,
-            marginTop: 0
+            marginTop: 0,
+            transform: rotationTransformValue
         };
     }
 

--- a/src/Image.js
+++ b/src/Image.js
@@ -61,6 +61,18 @@ class Image extends Component {
             case 8:
                 rotationTransformValue = "rotate(270deg)";
                 break;
+            case 2:
+                rotationTransformValue = "rotateY(180deg)";
+                break;
+            case 4:
+                rotationTransformValue = "rotate(180deg) rotateY(180deg)";
+                break;
+            case 5:
+                rotationTransformValue = "rotate(270deg) rotateY(180deg)";
+                break;
+            case 7:
+                rotationTransformValue = "rotate(90deg) rotateY(180deg)";
+                break;
         }
         if (this.props.item.isSelected){
             var ratio = (this.props.item.scaletwidth / this.props.height);


### PR DESCRIPTION
Currently the library displays thumbnail images regardless of their orientation values which may cause images with exif orientation property values not equal 1 to be rotated as in this screenshot:
<img width="949" alt="problem" src="https://user-images.githubusercontent.com/6617388/35179028-9582ecd8-fd9a-11e7-8b27-a95371206ecf.PNG">

I've added a slight change to thumbnailStyle method in Image class and now it rotates images according to their orientation value, after adding this change and using it in my project, now images are displayed in a proper way regardless of their orientation values:
![capture](https://user-images.githubusercontent.com/6617388/35179081-5b8c7278-fd9b-11e7-89a4-c70d10c1838f.PNG)
