### PR TITLE
Add contentWindow check

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -261,7 +261,7 @@ class Gallery extends Component {
         };
         return (
                 <div id={this.props.id} className="ReactGridGallery" ref={(c) => this._gallery = c}>
-                    <iframe style={resizeIframeStyles} ref={(c) => c && c.contentWindow.addEventListener('resize', this.onResize) } />
+                    <iframe style={resizeIframeStyles} ref={(c) => c && c.contentWindow && c.contentWindow.addEventListener('resize', this.onResize) } />
                 {images}
                 <Lightbox
             images={this.props.images}


### PR DESCRIPTION
When running tests using jest, this component would throw the error: `TypeError: Cannot read property 'addEventListener' of null`, adding the check fixed the issue. Figured others might run into the same issue so created a PR.