### PR TITLE
Nano image

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ src                     | string        | undefined     | Required. A string ref
 thumbnail               | string        | undefined     | Required. A string referring to any valid image resource (file, url, etc).
 thumbnailWidth          | number        | undefined     | Required. Width of the thumbnail image.
 thumbnailHeight         | number        | undefined     | Required. Height of the thumbnail image.
-nano                    | string:base64 | undefined     | Optional. Thumbnail Base64 image will be injected to background under the main image, that is waiting for a loading. This is super helpful and fancy if you receive base64 images 4x4 pixels from server-side response.
+nano                    | string:base64 | undefined     | Optional. Thumbnail Base64 image will be injected to background under the main image, that is waiting for a loading. This is super helpful and fancy if you receive base64 images 4x4 pixels from the server-side response.
 alt                     | string        | ""            | Optional. Image alt attribute.
 tags                    | array         | undefined     | Optional. An array of objects containing tag attributes (value and title). e.g. `{value: "foo", title: "bar"}`
 isSelected              | bool          | undefined     | Optional. The selected state of the image.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ src                     | string        | undefined     | Required. A string ref
 thumbnail               | string        | undefined     | Required. A string referring to any valid image resource (file, url, etc).
 thumbnailWidth          | number        | undefined     | Required. Width of the thumbnail image.
 thumbnailHeight         | number        | undefined     | Required. Height of the thumbnail image.
+nano                    | string:base64 | undefined     | Optional. Thumbnail Base64 image will be injected to background under the main image, that is waiting for a loading. This is super helpful and fancy if you receive base64 images 4x4 pixels from server-side response.
 alt                     | string        | ""            | Optional. Image alt attribute.
 tags                    | array         | undefined     | Optional. An array of objects containing tag attributes (value and title). e.g. `{value: "foo", title: "bar"}`
 isSelected              | bool          | undefined     | Optional. The selected state of the image.

--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -313,6 +313,7 @@ Gallery.propTypes = {
     images: PropTypes.arrayOf(
         PropTypes.shape({
             src: PropTypes.string.isRequired,
+            nano: PropTypes.string,
             alt: PropTypes.string,
             thumbnail: PropTypes.string.isRequired,
             srcset: PropTypes.array,

--- a/src/Image.js
+++ b/src/Image.js
@@ -32,18 +32,26 @@ class Image extends Component {
     tileViewportStyle () {
         if (this.props.tileViewportStyle)
             return this.props.tileViewportStyle.call(this);
+        var nanoBase64Backgorund = {}
+        if(this.props.item.nano) {
+            nanoBase64Backgorund = { 
+                background: `url(${this.props.item.nano})`,
+                backgroundSize: 'cover',
+                backgroundPosition: 'center center'
+            }
+        }
         if (this.props.item.isSelected)
-            return {
+            return Object.assign({
                 width: this.props.item.vwidth -32,
                 height: this.props.height -32,
                 margin: 16,
-                overflow: "hidden"
-            };
-        return {
+                overflow: "hidden",
+            }, nanoBase64Backgorund);
+        return Object.assign({
             width: this.props.item.vwidth,
             height: this.props.height,
-            overflow: "hidden"
-        };
+            overflow: "hidden",
+        }, nanoBase64Backgorund);
     }
 
     thumbnailStyle () {


### PR DESCRIPTION
@benhowell Hi Ben.

I like your lib! Great job! =) Just wanna add some fancy things... maybe it will be helpful for some perfectionists.

"nano" - Optional. Thumbnail Base64 image will be injected to background under the main image, that is waiting for a loading. This is super helpful and fancy if you receive base64 images 4x4 pixels from the server-side response.

This is an example.

<img width="933" alt="screenshot 2018-09-30 00 00 53" src="https://user-images.githubusercontent.com/4578298/46250453-f65dde80-c443-11e8-86fe-62f25a2d449b.png">

<img width="930" alt="screenshot 2018-09-29 23 59 54" src="https://user-images.githubusercontent.com/4578298/46250454-f958cf00-c443-11e8-80a1-63a51d68890c.png">

Thanks!