### PR TITLE
Fix crash when this.props.images.length - 1 < this.state.currentImage

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -30,6 +30,9 @@ class Gallery extends Component {
     }
 
     componentWillReceiveProps (np) {
+        if (this.state.currentImage > np.images.length - 1) {
+            this.setState({currentImage: np.images.length - 1});
+        }
         if(this.state.images != np.images || this.props.maxRows != np.maxRows){
             this.setState({
                 images: np.images,


### PR DESCRIPTION
In [demo](https://benhowell.github.io/react-grid-gallery/#custom-controls), when start deleting images at index [1, this.props.images.length-1], the component will crash when the image being deleted is the last one in the array. This commit fixes this issue.

The issue can be reproduced within the given demo.