### PR TITLE
Move build grid util function to separate file

### DIFF
--- a/src/renderThumbs.js
+++ b/src/renderThumbs.js
@@ -1,0 +1,91 @@
+const calculateCutOff = (len, delta, items) => {
+  const cutoff = [];
+  let cutsum = 0;
+  for (var i in items) {
+    const item = items[i];
+    const fractOfLen = item.scaletwidth / len;
+    cutoff[i] = Math.floor(fractOfLen * delta);
+    cutsum += cutoff[i];
+  }
+
+  let stillToCutOff = delta - cutsum;
+  while (stillToCutOff > 0) {
+    for (i in cutoff) {
+      cutoff[i]++;
+      stillToCutOff--;
+      if (stillToCutOff < 0) break;
+    }
+  }
+  return cutoff;
+};
+
+const buildImageRow = (data, { containerWidth, margin }) => {
+  const row = [];
+  let len = 0;
+  const imgMargin = 2 * margin;
+  while (data.items.length > 0 && len < containerWidth) {
+    var item = data.items.shift();
+    row.push(item);
+    len += item.scaletwidth + imgMargin;
+  }
+
+  const delta = len - containerWidth;
+  if (row.length > 0 && delta > 0) {
+    const cutoff = calculateCutOff(len, delta, row);
+    for (const i in row) {
+      const pixelsToRemove = cutoff[i];
+      item = row[i];
+      item.marginLeft = -Math.abs(Math.floor(pixelsToRemove / 2));
+      item.vwidth = item.scaletwidth - pixelsToRemove;
+    }
+  } else {
+    for (const j in row) {
+      item = row[j];
+      item.marginLeft = 0;
+      item.vwidth = item.scaletwidth;
+    }
+  }
+  return row;
+};
+
+const renderThumbs = (
+  images,
+  { containerWidth, maxRows, rowHeight, margin }
+) => {
+  rowHeight = typeof rowHeight === "undefined" ? 180 : rowHeight;
+  margin = typeof margin === "undefined" ? 2 : margin;
+
+  if (!images) return [];
+  if (!containerWidth) return [];
+
+  let items = images.slice();
+  items = items.map((item) => ({
+    ...item,
+    scaletwidth: Math.floor(
+      rowHeight * (item.thumbnailWidth / item.thumbnailHeight)
+    ),
+  }));
+  const data = { items };
+
+  const thumbs = [];
+  const rows = [];
+  while (data.items.length > 0) {
+    rows.push(buildImageRow(data, { containerWidth, margin }));
+  }
+
+  for (const r in rows) {
+    for (const i in rows[r]) {
+      const item = { ...rows[r][i], rowIndex: parseInt(r) };
+      if (maxRows) {
+        if (r < maxRows) {
+          thumbs.push(item);
+        }
+      } else {
+        thumbs.push(item);
+      }
+    }
+  }
+  return thumbs;
+};
+
+export default renderThumbs;

--- a/test/Gallery.test.js
+++ b/test/Gallery.test.js
@@ -130,6 +130,16 @@ describe("Gallery Component", () => {
     expect(screen.getByText("Vegetable")).toHaveStyle(tagStyle);
   });
 
+  it("should render all passed images after rerender", () => {
+    const { rerender } = render(<Gallery images={[image1]} />);
+
+    expect(getItems().length).toEqual(1);
+
+    rerender(<Gallery images={[image1, image2]} />);
+
+    expect(getItems().length).toEqual(2);
+  });
+
   describe("Image Options", () => {
     it("should set thumbnail image src attribute based on thumbnail prop", () => {
       render(<Gallery images={[image1]} />);

--- a/test/renderThumbs.test.js
+++ b/test/renderThumbs.test.js
@@ -1,0 +1,130 @@
+import renderThumbs from "./../src/renderThumbs";
+
+const image100x100 = { thumbnailWidth: 100, thumbnailHeight: 100 };
+
+describe("renderThumbs", () => {
+  it("should return empty array when images param not passed", () => {
+    const images = undefined;
+    const options = { containerWidth: 1000 };
+
+    const result = renderThumbs(images, options);
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return empty array when containerWidth isn't defined", () => {
+    const images = [image100x100];
+    const options = {};
+
+    const result = renderThumbs(images, options);
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return empty array when containerWidth is 0", () => {
+    const images = [image100x100];
+    const options = { containerWidth: 0 };
+
+    const result = renderThumbs(images, options);
+
+    expect(result).toEqual([]);
+  });
+
+  it("should not modify passed images array", () => {
+    const images = [image100x100];
+    const options = { containerWidth: 100 };
+
+    const result = renderThumbs(images, options);
+
+    expect(result).not.toBe(images);
+  });
+
+  it("should limit number of items when maxRows param passed", () => {
+    const images = [image100x100, image100x100, image100x100];
+    const options = {
+      containerWidth: 100,
+      rowHeight: 100,
+      margin: 0,
+      maxRows: 1,
+    };
+
+    const result = renderThumbs(images, options);
+
+    expect(result).toEqual([expect.objectContaining({ rowIndex: 0 })]);
+  });
+
+  it("should not compress image when it's narrower than container", () => {
+    const images = [image100x100];
+    const options = { containerWidth: 200, rowHeight: 100, margin: 0 };
+
+    const result = renderThumbs(images, options);
+
+    expect(result).toEqual([
+      expect.objectContaining({ rowIndex: 0, vwidth: 100, marginLeft: 0 }),
+    ]);
+  });
+
+  it("should compress image and calculate cut off when it's wider the container", () => {
+    const images = [image100x100];
+    const options = { containerWidth: 50, rowHeight: 100, margin: 0 };
+
+    const result = renderThumbs(images, options);
+
+    expect(result).toEqual([
+      expect.objectContaining({ rowIndex: 0, vwidth: 50, marginLeft: -25 }),
+    ]);
+  });
+
+  it("should build a single row when images fit into it", () => {
+    const images = [image100x100, image100x100, image100x100];
+    const options = { containerWidth: 201, rowHeight: 100, margin: 0 };
+
+    const result = renderThumbs(images, options);
+
+    expect(result).toEqual([
+      expect.objectContaining({ rowIndex: 0, marginLeft: -16 }),
+      expect.objectContaining({ rowIndex: 0, marginLeft: -16 }),
+      expect.objectContaining({ rowIndex: 0, marginLeft: -16 }),
+    ]);
+  });
+
+  it("should build multiple rows when images don't fit into a single row", () => {
+    const images = [image100x100, image100x100, image100x100];
+    const options = { containerWidth: 200, rowHeight: 100, margin: 0 };
+
+    const result = renderThumbs(images, options);
+
+    expect(result).toEqual([
+      expect.objectContaining({ rowIndex: 0 }),
+      expect.objectContaining({ rowIndex: 0 }),
+      expect.objectContaining({ rowIndex: 1 }),
+    ]);
+  });
+
+  it("should build multiple rows when images could fit into a single row but also the margin is specified", () => {
+    const images = [image100x100, image100x100, image100x100];
+    const options = { containerWidth: 200, rowHeight: 100, margin: 5 };
+
+    const result = renderThumbs(images, options);
+
+    expect(result).toEqual([
+      expect.objectContaining({ rowIndex: 0, marginLeft: -5, vwidth: 90 }),
+      expect.objectContaining({ rowIndex: 0, marginLeft: -5, vwidth: 90 }),
+      expect.objectContaining({ rowIndex: 1, marginLeft: 0, vwidth: 100 }),
+    ]);
+  });
+
+  it("should fit multiple images into one row and calculate scaled width when rowHeight is specified", () => {
+    const options = { containerWidth: 201, rowHeight: 50, margin: 0 };
+    const images = [image100x100, image100x100, image100x100, image100x100];
+
+    const result = renderThumbs(images, options);
+
+    expect(result).toEqual([
+      expect.objectContaining({ rowIndex: 0, scaletwidth: 50, vwidth: 50 }),
+      expect.objectContaining({ rowIndex: 0, scaletwidth: 50, vwidth: 50 }),
+      expect.objectContaining({ rowIndex: 0, scaletwidth: 50, vwidth: 50 }),
+      expect.objectContaining({ rowIndex: 0, scaletwidth: 50, vwidth: 50 }),
+    ]);
+  });
+});


### PR DESCRIPTION
The main goal here is to separate logic and UI. Also, it makes it easier to test the util this way.

----

Breaking changes that occur due to this change:

In `onSelectImage` handler there is an image object that is passing as a second parameter. Before the change, this object contained computed properties such as `scaletwidth`, `vwidth`, and `marginLeft`. Now it is the same object that is passed in images props, with no extra properties.

But I consider it to be minor. And also it is not documented.