### PR TITLE
Add wrapper style prop to allow custom styles.

### DIFF
--- a/src/Gallery.tsx
+++ b/src/Gallery.tsx
@@ -10,7 +10,7 @@ export const Gallery = <T extends ImageInterface>(
 ): JSX.Element => {
   const galleryRef = useRef(null);
 
-  const { maxRows, rowHeight, margin, enableImageSelection } = props;
+  const { maxRows, rowHeight, margin, enableImageSelection, wrapperStyle } = props;
   const { defaultContainerWidth, images } = props;
 
   const [containerWidth, setContainerWidth] = useState(defaultContainerWidth);
@@ -49,7 +49,7 @@ export const Gallery = <T extends ImageInterface>(
   return (
     <div id={props.id} className="ReactGridGallery" ref={galleryRef}>
       <ResizeListener onResize={handleResize} />
-      <div style={styles.gallery}>
+      <div style={{ ...styles.gallery, ...wrapperStyle}}>
         {thumbnails.map((item, index) => (
           <Image
             key={item.key || index}

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,7 @@ export interface GalleryProps<T extends Image = Image> {
   thumbnailStyle?: StyleProp<T>;
   tagStyle?: StyleProp<T>;
   thumbnailImageComponent?: ComponentType<ThumbnailImageProps>;
+  wrapperStyle?: CSSProperties;
 }
 
 export interface CheckButtonProps {


### PR DESCRIPTION
It would be nice if user could apply custom styles to the gallery wrapper. For example, I would like to align images along the main axis by providing `{ justifyContent: "center" }`, because for mobile devices, there is only one column of images and the possibility to center them in this column would be great.