### PR TITLE
Replace deprecated `defaultProps` usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "sideEffects": false,
   "scripts": {
     "prepublishOnly": "npm run build",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf node_modules/.cache",
     "rollup:build": "rollup -c",
     "watch": "rollup -c -w",
     "build": "npm run clean && npm run rollup:build",

--- a/src/CheckButton.tsx
+++ b/src/CheckButton.tsx
@@ -2,10 +2,14 @@ import { useState } from "react";
 import * as styles from "./styles";
 import { CheckButtonProps } from "./types";
 
-export const CheckButton = (props: CheckButtonProps): JSX.Element => {
-  const { isSelected, isVisible, onClick } = props;
-  const { selectedColor, hoverColor, color } = props;
-
+export const CheckButton = ({
+  isSelected = false,
+  isVisible = true,
+  onClick,
+  color = "#FFFFFFB2",
+  selectedColor = "#4285F4FF",
+  hoverColor = "#FFFFFFFF",
+}: CheckButtonProps): JSX.Element => {
   const [hover, setHover] = useState(false);
 
   const circleStyle = { display: isSelected ? "block" : "none" };
@@ -56,12 +60,4 @@ export const CheckButton = (props: CheckButtonProps): JSX.Element => {
       </svg>
     </div>
   );
-};
-
-CheckButton.defaultProps = {
-  isSelected: false,
-  isVisible: true,
-  color: "#FFFFFFB2",
-  selectedColor: "#4285F4FF",
-  hoverColor: "#FFFFFFFF",
 };

--- a/src/Gallery.tsx
+++ b/src/Gallery.tsx
@@ -5,13 +5,22 @@ import { buildLayoutFlat } from "./buildLayout";
 import { Image as ImageInterface, GalleryProps } from "./types";
 import * as styles from "./styles";
 
-export const Gallery = <T extends ImageInterface>(
-  props: GalleryProps<T>
-): JSX.Element => {
+export const Gallery = <T extends ImageInterface>({
+  images,
+  id = "ReactGridGallery",
+  enableImageSelection = true,
+  onSelect = () => {},
+  rowHeight = 180,
+  maxRows,
+  margin = 2,
+  defaultContainerWidth = 0,
+  onClick = () => {},
+  tileViewportStyle,
+  thumbnailStyle,
+  tagStyle,
+  thumbnailImageComponent,
+}: GalleryProps<T>): JSX.Element => {
   const galleryRef = useRef(null);
-
-  const { maxRows, rowHeight, margin, enableImageSelection } = props;
-  const { defaultContainerWidth, images } = props;
 
   const [containerWidth, setContainerWidth] = useState(defaultContainerWidth);
 
@@ -39,15 +48,15 @@ export const Gallery = <T extends ImageInterface>(
 
   const handleSelect = (index: number, event: MouseEvent<HTMLElement>) => {
     event.preventDefault();
-    props.onSelect(index, images[index], event);
+    onSelect(index, images[index], event);
   };
 
   const handleClick = (index: number, event: MouseEvent<HTMLElement>) => {
-    props.onClick(index, images[index], event);
+    onClick(index, images[index], event);
   };
 
   return (
-    <div id={props.id} className="ReactGridGallery" ref={galleryRef}>
+    <div id={id} className="ReactGridGallery" ref={galleryRef}>
       <ResizeListener onResize={handleResize} />
       <div style={styles.gallery}>
         {thumbnails.map((item, index) => (
@@ -60,10 +69,10 @@ export const Gallery = <T extends ImageInterface>(
             isSelectable={enableImageSelection}
             onClick={handleClick}
             onSelect={handleSelect}
-            tagStyle={props.tagStyle}
-            tileViewportStyle={props.tileViewportStyle}
-            thumbnailStyle={props.thumbnailStyle}
-            thumbnailImageComponent={props.thumbnailImageComponent}
+            tagStyle={tagStyle}
+            tileViewportStyle={tileViewportStyle}
+            thumbnailStyle={thumbnailStyle}
+            thumbnailImageComponent={thumbnailImageComponent}
           />
         ))}
       </div>
@@ -72,13 +81,3 @@ export const Gallery = <T extends ImageInterface>(
 };
 
 Gallery.displayName = "Gallery";
-
-Gallery.defaultProps = {
-  id: "ReactGridGallery",
-  enableImageSelection: true,
-  rowHeight: 180,
-  margin: 2,
-  defaultContainerWidth: 0,
-  onClick: () => {},
-  onSelect: () => {},
-};

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -4,32 +4,52 @@ import { ImageExtended, ImageProps } from "./types";
 import * as styles from "./styles";
 import { getStyle } from "./styles";
 
-export const Image = <T extends ImageExtended>(
-  props: ImageProps<T>
-): JSX.Element => {
-  const { item, thumbnailImageComponent: ThumbnailImageComponent } = props;
+export const Image = <T extends ImageExtended>({
+  item,
+  thumbnailImageComponent: ThumbnailImageComponent,
+  isSelectable = true,
+  thumbnailStyle,
+  tagStyle,
+  tileViewportStyle,
+  margin,
+  index,
+  onSelect,
+  onClick,
+}: ImageProps<T>): JSX.Element => {
   const styleContext = { item };
 
   const [hover, setHover] = useState(false);
 
   const thumbnailProps = {
-    key: props.index,
+    key: index,
     "data-testid": "grid-gallery-item_thumbnail",
     src: item.src,
     alt: item.alt ? item.alt : "",
     title: typeof item.caption === "string" ? item.caption : null,
-    style: getStyle(props.thumbnailStyle, styles.thumbnail, styleContext),
+    style: getStyle(thumbnailStyle, styles.thumbnail, styleContext),
   };
 
   const handleCheckButtonClick = (event: MouseEvent<HTMLElement>) => {
-    if (!props.isSelectable) {
+    if (!isSelectable) {
       return;
     }
-    props.onSelect(props.index, event);
+    onSelect(index, event);
   };
 
   const handleViewportClick = (event: MouseEvent<HTMLElement>) => {
-    props.onClick(props.index, event);
+    onClick(index, event);
+  };
+
+  const thumbnailImageProps = {
+    item,
+    index,
+    margin,
+    onSelect,
+    onClick,
+    isSelectable,
+    tileViewportStyle,
+    thumbnailStyle,
+    tagStyle,
   };
 
   return (
@@ -38,7 +58,7 @@ export const Image = <T extends ImageExtended>(
       data-testid="grid-gallery-item"
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
-      style={styles.galleryItem({ margin: props.margin })}
+      style={styles.galleryItem({ margin })}
     >
       <div
         className="ReactGridGallery_tile-icon-bar"
@@ -46,7 +66,7 @@ export const Image = <T extends ImageExtended>(
       >
         <CheckButton
           isSelected={item.isSelected}
-          isVisible={item.isSelected || (props.isSelectable && hover)}
+          isVisible={item.isSelected || (isSelectable && hover)}
           onClick={handleCheckButtonClick}
         />
       </div>
@@ -62,9 +82,7 @@ export const Image = <T extends ImageExtended>(
               title={tag.title}
               style={styles.tagItemBlock}
             >
-              <span
-                style={getStyle(props.tagStyle, styles.tagItem, styleContext)}
-              >
+              <span style={getStyle(tagStyle, styles.tagItem, styleContext)}>
                 {tag.value}
               </span>
             </div>
@@ -84,22 +102,21 @@ export const Image = <T extends ImageExtended>(
       <div
         className="ReactGridGallery_tile-overlay"
         style={styles.tileOverlay({
-          showOverlay: hover && !item.isSelected && props.isSelectable,
+          showOverlay: hover && !item.isSelected && isSelectable,
         })}
       />
 
       <div
         className="ReactGridGallery_tile-viewport"
         data-testid="grid-gallery-item_viewport"
-        style={getStyle(
-          props.tileViewportStyle,
-          styles.tileViewport,
-          styleContext
-        )}
+        style={getStyle(tileViewportStyle, styles.tileViewport, styleContext)}
         onClick={handleViewportClick}
       >
         {ThumbnailImageComponent ? (
-          <ThumbnailImageComponent {...props} imageProps={thumbnailProps} />
+          <ThumbnailImageComponent
+            {...thumbnailImageProps}
+            imageProps={thumbnailProps}
+          />
         ) : (
           <img {...thumbnailProps} />
         )}
@@ -114,8 +131,4 @@ export const Image = <T extends ImageExtended>(
       )}
     </div>
   );
-};
-
-Image.defaultProps = {
-  isSelectable: true,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,14 +61,14 @@ export interface ImageProps<T extends ImageExtended = ImageExtended> {
   item: T;
   index: number;
   margin: number;
-  height: number;
   isSelectable: boolean;
   onClick: (index: number, event: MouseEvent<HTMLElement>) => void;
   onSelect: (index: number, event: MouseEvent<HTMLElement>) => void;
   tileViewportStyle: StyleProp<T>;
   thumbnailStyle: StyleProp<T>;
   tagStyle: StyleProp<T>;
-  thumbnailImageComponent: ComponentType<ThumbnailImageProps>;
+  height?: number;
+  thumbnailImageComponent?: ComponentType<ThumbnailImageProps>;
 }
 
 export interface ThumbnailImageComponentImageProps {
@@ -104,7 +104,7 @@ export interface CheckButtonProps {
   isSelected: boolean;
   isVisible: boolean;
   onClick: (event: MouseEvent<HTMLElement>) => void;
-  color: string;
-  selectedColor: string;
-  hoverColor: string;
+  color?: string;
+  selectedColor?: string;
+  hoverColor?: string;
 }


### PR DESCRIPTION
Default props is deprecated for functional components https://github.com/facebook/react/pull/25699 and gives this error the console:

```
Warning: App: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
```

This PR implements the recommended solution. I ran all the unit test, integration tests, and all of the examples. Everything seems to be working as before!