### PR TITLE
fix: memo image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "react-grid-gallery",
       "version": "1.0.1",
       "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
       "devDependencies": {
         "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.24.5",
@@ -22,6 +25,7 @@
         "@types/jest": "^29.5.5",
         "@types/jest-environment-puppeteer": "^5.0.4",
         "@types/jest-image-snapshot": "^6.4.0",
+        "@types/lodash-es": "^4.17.12",
         "@types/react": "^18.2.28",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -3771,6 +3775,21 @@
         "@types/node": "*",
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmmirror.com/@types/lodash/-/lodash-4.17.1.tgz",
+      "integrity": "sha512-X+2qazGS3jxLAIz5JDXDzglAF3KpijdhFxlf/V1+hEsOUc+HnWi81L/uv/EvGuV90WY+7mPGFCUDGfQC3Gj95Q==",
+      "dev": true
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
       }
     },
     "node_modules/@types/node": {
@@ -8885,6 +8904,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -14013,6 +14037,21 @@
         "parse5": "^7.0.0"
       }
     },
+    "@types/lodash": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmmirror.com/@types/lodash/-/lodash-4.17.1.tgz",
+      "integrity": "sha512-X+2qazGS3jxLAIz5JDXDzglAF3KpijdhFxlf/V1+hEsOUc+HnWi81L/uv/EvGuV90WY+7mPGFCUDGfQC3Gj95Q==",
+      "dev": true
+    },
+    "@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/node": {
       "version": "18.7.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
@@ -17783,6 +17822,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/jest": "^29.5.5",
     "@types/jest-environment-puppeteer": "^5.0.4",
     "@types/jest-image-snapshot": "^6.4.0",
+    "@types/lodash-es": "^4.17.12",
     "@types/react": "^18.2.28",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
@@ -86,5 +87,8 @@
   "bugs": {
     "url": "https://github.com/benhowell/react-grid-gallery/issues"
   },
-  "homepage": "https://benhowell.github.io/react-grid-gallery/"
+  "homepage": "https://benhowell.github.io/react-grid-gallery/",
+  "dependencies": {
+    "lodash-es": "^4.17.21"
+  }
 }

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -3,10 +3,10 @@ import { CheckButton } from "./CheckButton";
 import { ImageExtended, ImageProps } from "./types";
 import * as styles from "./styles";
 import { getStyle } from "./styles";
+import isEqual from "lodash-es/isEqual";
 
 const imagePropsAreEqual = (prevProps: ImageProps, currProps: ImageProps) => {
   // states are the same iff the props are the same
-
   const {
     item: prevItem,
     index: prevIndex,
@@ -24,17 +24,11 @@ const imagePropsAreEqual = (prevProps: ImageProps, currProps: ImageProps) => {
   } = currProps;
 
   return (
-      prevItem.src === currItem.src &&
-      prevItem.width === currItem.width &&
-      prevItem.height === currItem.height &&
-      prevItem.scaledHeight === currItem.scaledHeight &&
-      prevItem.scaledWidth === currItem.scaledWidth &&
-      prevItem.viewportWidth === currItem.viewportWidth &&
-      prevItem.marginLeft === currItem.marginLeft &&
-      prevIndex === currIndex &&
-      prevMargin === currMargin &&
-      prevHeight === currHeight &&
-      prevIsSelectable === currIsSelectable
+    isEqual(prevItem, currItem) &&
+    isEqual(prevIndex, currIndex) &&
+    isEqual(prevMargin, currMargin) &&
+    isEqual(prevHeight, currHeight) &&
+    isEqual(prevIsSelectable, currIsSelectable)
   );
 };
 


### PR DESCRIPTION
After pulling the latest code today, I found that the image selection not work, and there was no selection effect after clicking the icon. 
The problem is that after adding the memo of the <Image /> component, the judgment of prevItem.isSeleted is ignored.
We can directly add an `isSeleted` judgment, but I think it might be simpler to use lodash.